### PR TITLE
Declare usage function as public static

### DIFF
--- a/ee2/system/expressionengine/third_party/link_icon/pi.link_icon.php
+++ b/ee2/system/expressionengine/third_party/link_icon/pi.link_icon.php
@@ -132,7 +132,7 @@
   // This function describes how the plugin is used.
   //  Make sure and use output buffering
 
-  function usage() {
+  public static function usage() {
     ob_start(); 
     ?>
     Use as follows:


### PR DESCRIPTION
Without this the most recent versions of EE will throw a PHP Notice/Warning
